### PR TITLE
Allowing for extension of BaseLoggerTarget

### DIFF
--- a/Source/BaseLoggerTarget.swift
+++ b/Source/BaseLoggerTarget.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class BaseLoggerTarget: LoggerTarget {
+open class BaseLoggerTarget: LoggerTarget {
     
     public var minimumLogLevel: LogLevel?
     


### PR DESCRIPTION
I was looking at your example and found BaseLoggerTarget wasn't extensible due to Swift 3's new access modifiers.  This PR uses the new `open` modifier.  I verified the original behavior in [meschbach/swifty-logger-derived](https://github.com/meschbach/swifty-logger-derived) and that it's been fixed with this patch.