### PR TITLE
Notes mutations on the LoggerFactory and implements builder pattern

### DIFF
--- a/Source/ConsoleLogger.swift
+++ b/Source/ConsoleLogger.swift
@@ -20,9 +20,8 @@ public class ConsoleLogger: BaseLoggerTarget {
 
 public extension LoggerFactory {
     
-    public func addCosole()  -> LoggerFactory {
-        self.addTarget(ConsoleLogger())
-        return self
+    public mutating func addCosole()  -> LoggerFactory {
+        return self.addTarget(ConsoleLogger())
     }
     
 }

--- a/Source/DefaultLoggerFactory.swift
+++ b/Source/DefaultLoggerFactory.swift
@@ -23,8 +23,9 @@ public class DefaultLoggerFactory: LoggerFactory {
         return  DefaultLogger(loggerFactory: self)
     }
     
-    public func addTarget(_ target: LoggerTarget) {
+    public func addTarget(_ target: LoggerTarget) -> LoggerFactory {
         loggerTargets.append(target)
+        return self
     }
     
 }

--- a/Source/FileLogger.swift
+++ b/Source/FileLogger.swift
@@ -107,14 +107,12 @@ extension FileLogger {
 
 public extension LoggerFactory {
     
-    public func addFile(_ fileName: String = FileLogger.defultFileName)  -> LoggerFactory {
-        self.addTarget(FileLogger(fileName: fileName))
-        return self
+    public mutating func addFile(_ fileName: String = FileLogger.defultFileName)  -> LoggerFactory {
+        return self.addTarget(FileLogger(fileName: fileName))
     }
     
-    public func addFile(_ fileURL: URL)  -> LoggerFactory {
-        self.addTarget(FileLogger(fileURL: fileURL))
-        return self
+    public mutating func addFile(_ fileURL: URL)  -> LoggerFactory {
+        return self.addTarget(FileLogger(fileURL: fileURL))
     }
     
 }

--- a/Source/LoggerFactory.swift
+++ b/Source/LoggerFactory.swift
@@ -17,7 +17,7 @@ public protocol LoggerFactory {
     var loggerTargets: [LoggerTarget] { get set }
     
     func makeLogger() -> Logger
-    
-    func addTarget(_ target: LoggerTarget) -> Void
-    
+
+    mutating func addTarget(_ target: LoggerTarget) -> LoggerFactory
+
 }


### PR DESCRIPTION
Happy new year @mtynior !

In the README you showed the builder pattern for the `LoggerFactory` so I updated it and friends to comply with that.  Additionally I was receiving warnings I should be using `let` instead of `var`, even though I was mutating the `DefaultLoggerFactory` so I marked the guilty methods with `mutating` to resolve the warning properly.